### PR TITLE
Fix min max range for ScanCapability.Impact

### DIFF
--- a/tr-181-2-17-0-wifi-de.xml
+++ b/tr-181-2-17-0-wifi-de.xml
@@ -4475,7 +4475,7 @@
         </description>
         <syntax>
           <unsignedInt>
-            <range maxInclusive="3"/>
+            <range minInclusive="1" maxInclusive="4"/>
           </unsignedInt>
         </syntax>
       </parameter>


### PR DESCRIPTION
Device.WiFi.DataElements.Network.Device.{i}.Radio.{i}.ScanCapability.Impact description and range does not match, value 0 does not defined in description and value 4 does not meets the range criterion.

```xml
<parameter name="Impact" access="readOnly">
<description>
Scan Impact of using this radio to perform a scan. : 1: No impact, : 2: Reduced number of spatial streams, : 3: Time slicing impairment, : 4: Radio unavailable for >= 2 seconds.
</description>
<syntax>
<unsignedInt>
<range maxInclusive="3"/>
</unsignedInt>
</syntax>
</parameter>
```